### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -29,7 +29,7 @@ jobs:
     #   run: cd server && mkdir -p certs && cd certs && openssl genrsa > privkey.pem && openssl req -new -x509 -key privkey.pem -subj "/C=CN/ST=SH/L=Springfield/O=Dis/CN=www.example.com" > fullchain.pem
 
     - name: Build & Publish to Github Container Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.IMAGE_NAME }}
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore